### PR TITLE
Fix damaris build

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -592,6 +592,7 @@ list (APPEND PUBLIC_HEADER_FILES
 
 if (Damaris_FOUND AND MPI_FOUND)
   list (APPEND PUBLIC_HEADER_FILES ebos/damariswriter.hh)
+  list (APPEND PUBLIC_HEADER_FILES opm/simulators/utils/DamarisVar.hpp)
 endif()
 
 if(HDF5_FOUND)

--- a/ebos/FIBlackOilModel.hpp
+++ b/ebos/FIBlackOilModel.hpp
@@ -61,8 +61,9 @@ public:
 
     void invalidateAndUpdateIntensiveQuantities(unsigned timeIdx) const
     {
-        this->invalidateIntensiveQuantitiesCache(timeIdx);
 
+        this->invalidateIntensiveQuantitiesCache(timeIdx);
+        OPM_BEGIN_PARALLEL_TRY_CATCH()
         // loop over all elements...
         ThreadedEntityIterator<GridView, /*codim=*/0> threadedElemIt(this->gridView_);
 #ifdef _OPENMP
@@ -77,12 +78,14 @@ public:
                 elemCtx.updatePrimaryIntensiveQuantities(timeIdx);
             }
         }
+        OPM_END_PARALLEL_TRY_CATCH("InvalideAndUpdateIntensiveQuantities: state error", this->simulator_.vanguard().grid().comm());
     }
 
     void invalidateAndUpdateIntensiveQuantitiesOverlap(unsigned timeIdx) const
     {
         // loop over all elements
         ThreadedEntityIterator<GridView, /*codim=*/0> threadedElemIt(this->gridView_);
+        OPM_BEGIN_PARALLEL_TRY_CATCH()
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
@@ -105,6 +108,7 @@ public:
                 elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
             }
         }
+        OPM_END_PARALLEL_TRY_CATCH("InvalideAndUpdateIntensiveQuantitiesOverlap: state error", this->simulator_.vanguard().grid().comm());
     }
 
     template <class GridSubDomain>

--- a/ebos/damariswriter.hh
+++ b/ebos/damariswriter.hh
@@ -361,7 +361,7 @@ private:
         }
         // Damaris parameters only support int data types. This will limit models to be under size of 2^32-1 elements
         // ToDo: Do we need to check that n_elements_global_max will fit in a C int type (INT_MAX)
-        if( n_elements_global_max <= INT_MAX ) {
+        if( n_elements_global_max <= std::numeric_limits<int>::max()) {
             temp_int = static_cast<int>(n_elements_global_max);
             dam_err_ = damaris_parameter_set("n_elements_total", &temp_int, sizeof(int));
             if (dam_err_ != DAMARIS_OK && rank_ == 0) {
@@ -369,8 +369,10 @@ private:
                               "damaris_parameter_set(\"n_elements_total\", &temp_int, sizeof(int));");
             }
         } else {
-            OpmLog::error(fmt::format("The size of the global array ({}) is greater than what a Damaris paramater type supports ({}).  ", n_elements_global_max, INT_MAX ));
-            assert( n_elements_global_max < INT_MAX ) ;
+            OpmLog::error(fmt::format("The size of the global array ({}) is greater than "
+                                      "what a Damaris parameter type supports ({}).",
+                                      n_elements_global_max, std::numeric_limits<int>::max()));
+            assert( n_elements_global_max < std::numeric_limits<int>::max()) ;
         }
 
         // Use damaris_set_position to set the offset in the global size of the array.

--- a/ebos/ebos.hh
+++ b/ebos/ebos.hh
@@ -34,7 +34,7 @@
 #include <opm/models/utils/start.hh>
 
 #include <opm/simulators/aquifers/BlackoilAquiferModel.hpp>
-#include <opm/simulators/linalg/ISTLSolverEbos.hpp>
+#include <opm/simulators/linalg/ISTLSolverEbosBda.hpp>
 #include <opm/simulators/wells/BlackoilWellModel.hpp>
 
 namespace Opm {

--- a/ebos/ebos.hh
+++ b/ebos/ebos.hh
@@ -34,7 +34,7 @@
 #include <opm/models/utils/start.hh>
 
 #include <opm/simulators/aquifers/BlackoilAquiferModel.hpp>
-#include <opm/simulators/linalg/ISTLSolverEbosBda.hpp>
+#include <opm/simulators/linalg/ISTLSolverEbos.hpp>
 #include <opm/simulators/wells/BlackoilWellModel.hpp>
 
 namespace Opm {
@@ -111,6 +111,11 @@ struct EclAquiferModel<TypeTag, TTag::EbosTypeTag> {
 template<class TypeTag>
 struct LinearSolverSplice<TypeTag, TTag::EbosTypeTag> {
     using type = TTag::FlowIstlSolver;
+};
+
+template<>
+struct LinearSolverBackend<TTag::EbosTypeTag, TTag::FlowIstlSolverParams> {
+    using type = ISTLSolverEbos<TTag::EbosTypeTag>;
 };
 
 // the default for the allowed volumetric error for oil per second

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -225,6 +225,7 @@ public:
 #if HAVE_DAMARIS
         EWOMS_REGISTER_PARAM(TypeTag, bool, EnableDamarisOutput,
                              "Write a specific variable using Damaris in a separate core");
+                             
 #endif
         EWOMS_REGISTER_PARAM(TypeTag, bool, EclOutputDoublePrecision,
                              "Tell the output writer to use double precision. Useful for 'perfect' restarts");

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -225,7 +225,6 @@ public:
 #if HAVE_DAMARIS
         EWOMS_REGISTER_PARAM(TypeTag, bool, EnableDamarisOutput,
                              "Write a specific variable using Damaris in a separate core");
-                             
 #endif
         EWOMS_REGISTER_PARAM(TypeTag, bool, EclOutputDoublePrecision,
                              "Tell the output writer to use double precision. Useful for 'perfect' restarts");

--- a/ebos/eclproblem_properties.hh
+++ b/ebos/eclproblem_properties.hh
@@ -427,7 +427,7 @@ struct DamarisSharedMemeorySizeBytes<TypeTag, TTag::EclBaseProblem> {
 };
 template<class TypeTag>
 struct DamarisLogLevel<TypeTag, TTag::EclBaseProblem> {
-    static constexpr auto value = "trace";
+    static constexpr auto value = "info";
 };
 
 #endif

--- a/ebos/eclproblem_properties.hh
+++ b/ebos/eclproblem_properties.hh
@@ -392,12 +392,44 @@ template<class TypeTag>
 struct EnableDamarisOutput<TypeTag, TTag::EclBaseProblem> {
     static constexpr bool value = false;
 };
-
 // If Damaris is available, write specific variable output in parallel
 template<class TypeTag>
 struct EnableDamarisOutputCollective<TypeTag, TTag::EclBaseProblem> {
     static constexpr bool value = true;
 };
+template<class TypeTag>
+struct DamarisSaveToHdf<TypeTag, TTag::EclBaseProblem> {
+    static constexpr bool value = true;
+};
+template<class TypeTag>
+struct DamarisPythonScript<TypeTag, TTag::EclBaseProblem> {
+    static constexpr auto value = "";
+};
+template<class TypeTag>
+struct DamarisPythonParaviewScript<TypeTag, TTag::EclBaseProblem> {
+    static constexpr auto value = "";
+};
+template<class TypeTag>
+struct DamarisSimName<TypeTag, TTag::EclBaseProblem> {
+    static constexpr auto value = "";
+};
+template<class TypeTag>
+struct DamarisDedicatedCores<TypeTag, TTag::EclBaseProblem> {
+    static constexpr int value = 1;
+};
+template<class TypeTag>
+struct DamarisDedicatedNodes<TypeTag, TTag::EclBaseProblem> {
+    static constexpr int value = 0;
+};
+template<class TypeTag>
+struct DamarisSharedMemeorySizeBytes<TypeTag, TTag::EclBaseProblem> {
+    static constexpr long value = 536870912;
+};
+template<class TypeTag>
+struct DamarisLogLevel<TypeTag, TTag::EclBaseProblem> {
+    static constexpr auto value = "trace";
+};
+
 #endif
 // If available, write the ECL output in a non-blocking manner
 template<class TypeTag>

--- a/opm/simulators/flow/Main.cpp
+++ b/opm/simulators/flow/Main.cpp
@@ -239,41 +239,9 @@ void Main::setupDamaris(const std::string& outputDir )
     if (!outputDir.empty()) {
         ensureOutputDirExists(outputDir);
     }
-    
-    bool enableDamarisOutputCollective = true ;
-    bool saveToDamarisHDF5 = true ;
-    std::string damarisPythonFilename = "" ;
-    std::string damarisPythonParaviewFilename = "" ;
-    
-    std::string damarisSimName  = ""       ; // empty defaults to opm-sim-<magic_number>
-    std::string damarisLogLevel = "info"   ;
-    int nDamarisCores   = 1 ;
-    int nDamarisNodes   = 0 ;
-    long shmemSizeBytes = 536870912 ;
-    
-    enableDamarisOutputCollective = EWOMS_GET_PARAM(PreTypeTag, bool, EnableDamarisOutputCollective) ;
-    saveToDamarisHDF5             = EWOMS_GET_PARAM(PreTypeTag, bool, DamarisSaveToHdf);
-    damarisPythonFilename         = EWOMS_GET_PARAM(PreTypeTag, std::string, DamarisPythonScript);
-    damarisPythonParaviewFilename = EWOMS_GET_PARAM(PreTypeTag, std::string, DamarisPythonParaviewScript);
-    damarisSimName                = EWOMS_GET_PARAM(PreTypeTag, std::string, DamarisSimName);
-    nDamarisCores                = EWOMS_GET_PARAM(PreTypeTag, int, DamarisDedicatedCores);
-    nDamarisNodes                 = EWOMS_GET_PARAM(PreTypeTag, int, DamarisDedicatedNodes);
-    shmemSizeBytes                = EWOMS_GET_PARAM(PreTypeTag, long, DamarisSharedMemeorySizeBytes);
-    damarisLogLevel                = EWOMS_GET_PARAM(PreTypeTag, std::string, DamarisLogLevel);
 
     std::map<std::string, std::string> find_replace_map ;
-    find_replace_map = Opm::DamarisOutput::DamarisKeywords(EclGenericVanguard::comm(),
-                                                           outputDir, 
-                                                           enableDamarisOutputCollective, 
-                                                           saveToDamarisHDF5, 
-                                                           nDamarisCores,
-                                                           nDamarisNodes,
-                                                           shmemSizeBytes,
-                                                           damarisPythonFilename,
-                                                           damarisSimName,
-                                                           damarisLogLevel,
-                                                           damarisPythonParaviewFilename
-                                                         );
+    find_replace_map = Opm::DamarisOutput::DamarisKeywords(EclGenericVanguard::comm(), outputDir);
     
     // By default EnableDamarisOutputCollective is true so all simulation results will
     // be written into one single file for each iteration using Parallel HDF5.

--- a/opm/simulators/flow/Main.cpp
+++ b/opm/simulators/flow/Main.cpp
@@ -233,20 +233,19 @@ void Main::setupVanguard()
 }
 
 #if HAVE_DAMARIS
-void Main::setupDamaris(const std::string& outputDir,
-                        const bool enableDamarisOutputCollective)
+void Main::setupDamaris(const std::string& outputDir , std::map<std::string, std::string>& find_replace_map)
 {
     if (!outputDir.empty()) {
         ensureOutputDirExists(outputDir);
     }
-
+    
     // By default EnableDamarisOutputCollective is true so all simulation results will
     // be written into one single file for each iteration using Parallel HDF5.
     // It set to false, FilePerCore mode is used in Damaris, then simulation results in each
     // node are aggregated by dedicated Damaris cores and stored to separate files per Damaris core.
     // Irrespective of mode, output is written asynchronously at the end of each timestep.
     // Using the ModifyModel class to set the XML file for Damaris.
-    DamarisOutput::initializeDamaris(EclGenericVanguard::comm(), EclGenericVanguard::comm().rank(), outputDir, enableDamarisOutputCollective);
+    DamarisOutput::initializeDamaris(EclGenericVanguard::comm(), EclGenericVanguard::comm().rank(), find_replace_map);
     int is_client;
     MPI_Comm new_comm;
     int err = damaris_start(&is_client);

--- a/opm/simulators/flow/Main.cpp
+++ b/opm/simulators/flow/Main.cpp
@@ -233,11 +233,47 @@ void Main::setupVanguard()
 }
 
 #if HAVE_DAMARIS
-void Main::setupDamaris(const std::string& outputDir , std::map<std::string, std::string>& find_replace_map)
+void Main::setupDamaris(const std::string& outputDir )
 {
+    typedef Properties::TTag::FlowEarlyBird PreTypeTag;
     if (!outputDir.empty()) {
         ensureOutputDirExists(outputDir);
     }
+    
+    bool enableDamarisOutputCollective = true ;
+    bool saveToDamarisHDF5 = true ;
+    std::string damarisPythonFilename = "" ;
+    std::string damarisPythonParaviewFilename = "" ;
+    
+    std::string damarisSimName  = ""       ; // empty defaults to opm-sim-<magic_number>
+    std::string damarisLogLevel = "info"   ;
+    int nDamarisCores   = 1 ;
+    int nDamarisNodes   = 0 ;
+    long shmemSizeBytes = 536870912 ;
+    
+    enableDamarisOutputCollective = EWOMS_GET_PARAM(PreTypeTag, bool, EnableDamarisOutputCollective) ;
+    saveToDamarisHDF5             = EWOMS_GET_PARAM(PreTypeTag, bool, DamarisSaveToHdf);
+    damarisPythonFilename         = EWOMS_GET_PARAM(PreTypeTag, std::string, DamarisPythonScript);
+    damarisPythonParaviewFilename = EWOMS_GET_PARAM(PreTypeTag, std::string, DamarisPythonParaviewScript);
+    damarisSimName                = EWOMS_GET_PARAM(PreTypeTag, std::string, DamarisSimName);
+    nDamarisCores                = EWOMS_GET_PARAM(PreTypeTag, int, DamarisDedicatedCores);
+    nDamarisNodes                 = EWOMS_GET_PARAM(PreTypeTag, int, DamarisDedicatedNodes);
+    shmemSizeBytes                = EWOMS_GET_PARAM(PreTypeTag, long, DamarisSharedMemeorySizeBytes);
+    damarisLogLevel                = EWOMS_GET_PARAM(PreTypeTag, std::string, DamarisLogLevel);
+
+    std::map<std::string, std::string> find_replace_map ;
+    find_replace_map = Opm::DamarisOutput::DamarisKeywords(EclGenericVanguard::comm(),
+                                                           outputDir, 
+                                                           enableDamarisOutputCollective, 
+                                                           saveToDamarisHDF5, 
+                                                           nDamarisCores,
+                                                           nDamarisNodes,
+                                                           shmemSizeBytes,
+                                                           damarisPythonFilename,
+                                                           damarisSimName,
+                                                           damarisLogLevel,
+                                                           damarisPythonParaviewFilename
+                                                         );
     
     // By default EnableDamarisOutputCollective is true so all simulation results will
     // be written into one single file for each iteration using Parallel HDF5.

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -72,7 +72,9 @@
 #include <opm/simulators/utils/ParallelEclipseState.hpp>
 #endif
 
-
+#if HAVE_DAMARIS
+#include <opm/simulators/utils/DamarisKeywords.hpp>
+#endif
 
 #include <cassert>
 #include <cstdlib>
@@ -95,10 +97,6 @@ struct FlowEarlyBird {
 }
 
 } // namespace Opm::Properties
-
-#if HAVE_DAMARIS
-#include <opm/simulators/utils/DamarisKeywords.hpp>
-#endif
 
 namespace Opm {
 

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -72,9 +72,7 @@
 #include <opm/simulators/utils/ParallelEclipseState.hpp>
 #endif
 
-#if HAVE_DAMARIS
-#include <opm/simulators/utils/DamarisKeywords.hpp>
-#endif
+
 
 #include <cassert>
 #include <cstdlib>
@@ -97,6 +95,10 @@ struct FlowEarlyBird {
 }
 
 } // namespace Opm::Properties
+
+#if HAVE_DAMARIS
+#include <opm/simulators/utils/DamarisKeywords.hpp>
+#endif
 
 namespace Opm {
 

--- a/opm/simulators/flow/Main.hpp
+++ b/opm/simulators/flow/Main.hpp
@@ -342,34 +342,9 @@ private:
             OpmLog::warning(msg);
             enableDamarisOutput_ = false ;
         }
-        
+
         if (enableDamarisOutput_) {
-            enableDamarisOutputCollective_ = EWOMS_GET_PARAM(PreTypeTag, bool, EnableDamarisOutputCollective) ;
-            saveToDamarisHDF5_             = EWOMS_GET_PARAM(PreTypeTag, bool, DamarisSaveToHdf);
-            damarisPythonFilename_         = EWOMS_GET_PARAM(PreTypeTag, std::string, DamarisPythonScript);
-            damarisPythonParaviewFilename_ = EWOMS_GET_PARAM(PreTypeTag, std::string, DamarisPythonParaviewScript);
-            damarisSimName_                = EWOMS_GET_PARAM(PreTypeTag, std::string, DamarisSimName);
-            
-            nDamarisCores_                 = EWOMS_GET_PARAM(PreTypeTag, int, DamarisDedicatedCores);
-            nDamarisNodes_                 = EWOMS_GET_PARAM(PreTypeTag, int, DamarisDedicatedNodes);
-            shmemSizeBytes_                = EWOMS_GET_PARAM(PreTypeTag, long, DamarisSharedMemeorySizeBytes);
-            
-            damarisLogLevel_                = EWOMS_GET_PARAM(PreTypeTag, std::string, DamarisLogLevel);
-            
-            std::map<std::string, std::string> find_replace_map ;
-            find_replace_map = Opm::DamarisOutput::DamarisKeywords(EclGenericVanguard::comm(),
-                                                                   outputDir, 
-                                                                   enableDamarisOutputCollective_, 
-                                                                   saveToDamarisHDF5_, 
-                                                                   nDamarisCores_,
-                                                                   nDamarisNodes_,
-                                                                   shmemSizeBytes_,
-                                                                   damarisPythonFilename_,
-                                                                   damarisSimName_,
-                                                                   damarisLogLevel_,
-                                                                   damarisPythonParaviewFilename_
-                                                                 );
-            this->setupDamaris(outputDir, find_replace_map);
+            this->setupDamaris(outputDir);
         }
 #endif // HAVE_DAMARIS
 
@@ -737,8 +712,7 @@ private:
     }
 
 #if HAVE_DAMARIS
-    void setupDamaris(const std::string& outputDir, 
-                       std::map<std::string, std::string>& find_replace_map);
+    void setupDamaris(const std::string& outputDir);
 #endif
 
     int argc_{0};
@@ -763,16 +737,6 @@ private:
     bool isSimulationRank_ = true;
 #if HAVE_DAMARIS
     bool enableDamarisOutput_ = false;
-    bool enableDamarisOutputCollective_ = true ;
-    bool saveToDamarisHDF5_ = true ;
-    std::string damarisPythonFilename_ = "" ;
-    std::string damarisPythonParaviewFilename_ = "" ;
-    
-    std::string damarisSimName_  = ""       ; // empty defaults to opm-sim-<magic_number>
-    std::string damarisLogLevel_ = "info"   ;
-    int nDamarisCores_   = 1 ;
-    int nDamarisNodes_   = 0 ;
-    long shmemSizeBytes_ = 536870912 ;
 #endif
 };
 

--- a/opm/simulators/linalg/FlowLinearSolverParameters.hpp
+++ b/opm/simulators/linalg/FlowLinearSolverParameters.hpp
@@ -220,7 +220,7 @@ struct OpenclIluParallel<TypeTag, TTag::FlowIstlSolverParams> {
 // Set the backend to be used.
 template<class TypeTag>
 struct LinearSolverBackend<TypeTag, TTag::FlowIstlSolverParams> {
-#if COMPLE_BDA_BRIDGE
+#if COMPILE_BDA_BRIDGE
     using type = ISTLSolverEbosBda<TypeTag>;
 #else
     using type = ISTLSolverEbos<TypeTag>;

--- a/opm/simulators/linalg/ISTLSolverEbosBda.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbosBda.hpp
@@ -216,7 +216,7 @@ public:
         OPM_TIMEBLOCK(solve);
         this->calls_ += 1;
         // Write linear system if asked for.
-        const int verbosity = this->prm_.template get<int>("verbosity", 0);
+        const int verbosity = this->prm_[this->activeSolverNum_].template get<int>("verbosity", 0);
         const bool write_matrix = verbosity > 10;
         if (write_matrix) {
             Helper::writeSystem(this->simulator_, //simulator is only used to get names
@@ -242,8 +242,8 @@ public:
                 // bda solve fails use istl solver setup need to be done since it is not setup in prepare
                 ParentType::prepareFlexibleSolver();
             }
-            assert(this->flexibleSolver_.solver_);
-            this->flexibleSolver_.solver_->apply(x, *(this->rhs_), result);
+            assert(this->flexibleSolver_[this->activeSolverNum_].solver_);
+            this->flexibleSolver_[this->activeSolverNum_].solver_->apply(x, *(this->rhs_), result);
         }
 
         // Check convergence, iterations etc.

--- a/opm/simulators/linalg/ISTLSolverEbosBda.hpp
+++ b/opm/simulators/linalg/ISTLSolverEbosBda.hpp
@@ -181,8 +181,9 @@ public:
     void prepare(const Matrix& M, Vector& b)
     {
         OPM_TIMEBLOCK(prepare);
-        const bool firstcall = (this->matrix_ == nullptr);
+        [[maybe_unused]] const bool firstcall = (this->matrix_ == nullptr);
         ParentType::prepare(M,b);
+
 #if HAVE_OPENCL
         // update matrix entries for solvers.
         if (firstcall && bdaBridge_) {

--- a/opm/simulators/utils/DamarisKeywords.cpp
+++ b/opm/simulators/utils/DamarisKeywords.cpp
@@ -20,13 +20,9 @@
 #include <config.h>
 #include <opm/simulators/flow/Main.hpp>
 
-
-
-#include <opm/models/utils/propertysystem.hh>
-#include <opm/models/utils/parametersystem.hh>
-
 #include <opm/simulators/utils/DamarisKeywords.hpp>
 #include <damaris/env/Environment.hpp>
+
 #include <string>
 #include <map>
 #include <random>
@@ -169,7 +165,7 @@ DamarisKeywords(MPI_Comm comm, std::string OutputDir)
         // and when one sim finishes it removes its shmem file.
         // simName_str =  damaris::Environment::GetMagicNumber(comm) ;
         if (simName_str == "") {
-            // We will add a random value as GetMagicNumber(comm) requires Damaris v1.9.3
+            // We will add a random value as GetMagicNumber(comm) requires Damaris v1.9.2
             // Seed with a real random value, if available
             std::random_device r;
             // Choose a random number between 0 and MAX_INT

--- a/opm/simulators/utils/DamarisKeywords.cpp
+++ b/opm/simulators/utils/DamarisKeywords.cpp
@@ -120,7 +120,7 @@ DamarisKeywords(MPI_Comm comm, std::string OutputDir)
     std::string disableParaviewXMLfin("--") ;
 
     // Test if input Python file exists and set the name of the script for <variable ...  script="" > )XML elements
-    std::string publishToPython_str("") ;
+    std::string publishToPython_str("#") ;
     if (pythonFilename != ""){
         if (FileExists(pythonFilename, comm, rank)) {
              publishToPython_str="PythonScript" ; // the name of the PyScript XML element
@@ -169,14 +169,14 @@ DamarisKeywords(MPI_Comm comm, std::string OutputDir)
         // and when one sim finishes it removes its shmem file.
         // simName_str =  damaris::Environment::GetMagicNumber(comm) ;
         if (simName_str == "") {
-            // We will add a random value as GetMagicNumber(comm) requires latest Damaris
+            // We will add a random value as GetMagicNumber(comm) requires Damaris v1.9.3
             // Seed with a real random value, if available
             std::random_device r;
             // Choose a random number between 0 and MAX_INT
             std::default_random_engine e1(r());
             std::uniform_int_distribution<int> uniform_dist(0, std::numeric_limits<int>::max());
             int rand_int = uniform_dist(e1);
-            simName_str =  std::to_string(rand_int) ;
+            simName_str = "opm-flow-" + std::to_string(rand_int) ;
         } else {
             simName_str = "opm-flow-" + simName_str ;
         }
@@ -210,9 +210,10 @@ DamarisKeywords(MPI_Comm comm, std::string OutputDir)
     }
 
     std::string logLevel_str(damarisLogLevel) ;
-
-   // _MAKE_AVAILABLE_IN_PYTHON_
-   // _PYTHON_SCRIPT_
+    std::string logFlush_str("false") ;
+    if ((logLevel_str == "debug") || (logLevel_str == "trace") ) {
+        logFlush_str = "true" ;
+    }
 
     std::map<std::string, std::string> damaris_keywords = {
         {"_SHMEM_BUFFER_BYTES_REGEX_", shmemSizeBytes_str},
@@ -228,6 +229,7 @@ DamarisKeywords(MPI_Comm comm, std::string OutputDir)
         {"_MAKE_AVAILABLE_IN_PYTHON_",publishToPython_str},  /* must match  <pyscript name="PythonScript" */
         {"_SIM_NAME_",simName_str},
         {"_LOG_LEVEL_",logLevel_str},
+        {"_LOG_FLUSH_",logFlush_str},
         {"_DISABLEPYTHONSTART_",disablePythonXMLstart},
         {"_DISABLEPYTHONFIN_",disablePythonXMLfin},
         {"_DISABLEPARAVIEWSTART_",disableParaviewXMLstart},

--- a/opm/simulators/utils/DamarisKeywords.hpp
+++ b/opm/simulators/utils/DamarisKeywords.hpp
@@ -22,7 +22,7 @@
 
 #include <string>
 #include <map>
-
+#include <mpi.h>
 /*
     Below is the std::map with the keywords that are supported by Damaris.
 
@@ -34,7 +34,17 @@
 namespace Opm::DamarisOutput
 {
 
-std::map<std::string,std::string> DamarisKeywords(std::string outputDir, bool enableDamarisOutputCollective);
+std::map<std::string, std::string>
+DamarisKeywords(MPI_Comm comm, std::string OutputDir, 
+                    bool enableDamarisOutputCollective, 
+                    bool saveToHDF5, 
+                    int  nDamarisCores,
+                    int  nDamarisNodes,
+                    long shmemSizeBytes,
+                    std::string pythonFilename, 
+                    std::string simName, 
+                    std::string logLevel,
+                    std::string paraviewPythonFilename ) ;
 
 } // namespace Opm::DamarisOutput
 

--- a/opm/simulators/utils/DamarisKeywords.hpp
+++ b/opm/simulators/utils/DamarisKeywords.hpp
@@ -22,7 +22,9 @@
 
 #include <string>
 #include <map>
+
 #include <mpi.h>
+
 /*
     Below is the std::map with the keywords that are supported by Damaris.
 
@@ -38,24 +40,22 @@ namespace Opm::DamarisOutput
 *   Returns true if the file exists. 
 *     Tests to see if filename string is empty 
 *     or the "#" character and if so returns false.
+*     Tests for file existance on ranl 0 and 
+*     passes result via MPI to all other ranks.
 */
 bool FileExists(const std::string filename_in, const MPI_Comm comm, const int rank) ;
 
 
 /** 
-*   Returns true if the file exists. Tests to see if filename string is empty or the "#" character and if so returns false.
+*   Creates the map of search strings and repacement strings that will be used to 
+*   modify a templated Damaris XML file which will be used to intialize Damaris.
+*   This function will access all the OPM flow comand line arguments related to
+*   Damaris and perform checks and logic so as to create a valid XML file. 
+*   N.B. The created XML file can be overridden using an environment variable 
+*   FLOW_DAMARIS_XML_FILE that points to a Damaris XML file. 
 */
 std::map<std::string, std::string>
-DamarisKeywords(MPI_Comm comm, std::string OutputDir, 
-                    bool enableDamarisOutputCollective, 
-                    bool saveToHDF5, 
-                    int  nDamarisCores,
-                    int  nDamarisNodes,
-                    long shmemSizeBytes,
-                    std::string pythonFilename, 
-                    std::string simName, 
-                    std::string logLevel,
-                    std::string paraviewPythonFilename ) ;
+DamarisKeywords(MPI_Comm comm, std::string OutputDir) ;
 
 } // namespace Opm::DamarisOutput
 

--- a/opm/simulators/utils/DamarisKeywords.hpp
+++ b/opm/simulators/utils/DamarisKeywords.hpp
@@ -33,7 +33,18 @@
 
 namespace Opm::DamarisOutput
 {
+    
+    /** 
+*   Returns true if the file exists. 
+*     Tests to see if filename string is empty 
+*     or the "#" character and if so returns false.
+*/
+bool FileExists(const std::string filename_in, const MPI_Comm comm, const int rank) ;
 
+
+/** 
+*   Returns true if the file exists. Tests to see if filename string is empty or the "#" character and if so returns false.
+*/
 std::map<std::string, std::string>
 DamarisKeywords(MPI_Comm comm, std::string OutputDir, 
                     bool enableDamarisOutputCollective, 

--- a/opm/simulators/utils/DamarisKeywords.hpp
+++ b/opm/simulators/utils/DamarisKeywords.hpp
@@ -23,7 +23,9 @@
 #include <string>
 #include <map>
 
-#include <mpi.h>
+#include <opm/simulators/utils/ParallelCommunication.hpp>
+
+#include <ebos/damariswriter.hh>
 
 /*
     Below is the std::map with the keywords that are supported by Damaris.
@@ -43,19 +45,53 @@ namespace Opm::DamarisOutput
 *     Tests for file existance on ranl 0 and 
 *     passes result via MPI to all other ranks.
 */
-bool FileExists(const std::string filename_in, const MPI_Comm comm, const int rank) ;
+bool FileExists(const std::string& filename_in,
+                const Parallel::Communication& comm);
 
+struct DamarisSettings {
+    bool enableDamarisOutputCollective = true ;
+    bool saveToDamarisHDF5 = true ;
+    std::string pythonFilename;
+    std::string paraviewPythonFilename;
 
-/** 
-*   Creates the map of search strings and repacement strings that will be used to 
+    std::string damarisSimName; // empty defaults to opm-sim-<magic_number>
+    std::string damarisLogLevel = "info";
+    int nDamarisCores   = 1 ;
+    int nDamarisNodes   = 0 ;
+    long shmemSizeBytes = 536870912 ;
+
+    std::map<std::string, std::string>
+    getKeywords(const Parallel::Communication& comm,
+                const std::string& OutputDir);
+};
+
+/**
+*   Creates the map of search strings and repacement strings that will be used to
 *   modify a templated Damaris XML file which will be used to intialize Damaris.
 *   This function will access all the OPM flow comand line arguments related to
-*   Damaris and perform checks and logic so as to create a valid XML file. 
-*   N.B. The created XML file can be overridden using an environment variable 
-*   FLOW_DAMARIS_XML_FILE that points to a Damaris XML file. 
+*   Damaris and perform checks and logic so as to create a valid XML file.
+*   N.B. The created XML file can be overridden using an environment variable
+*   FLOW_DAMARIS_XML_FILE that points to a Damaris XML file.
 */
+template<class TypeTag>
 std::map<std::string, std::string>
-DamarisKeywords(MPI_Comm comm, std::string OutputDir) ;
+DamarisKeywords(const Parallel::Communication& comm, const std::string& OutputDir)
+{
+    DamarisSettings settings;
+    // Get all of the Damaris keywords (except for --enable-damaris, which is used in simulators/flow/Main.hpp)
+    // These command line arguments are defined in ebos/damariswriter.hh and defaults are set in ebos/eclproblem_properties.hh
+    settings.enableDamarisOutputCollective = EWOMS_GET_PARAM(TypeTag, bool, EnableDamarisOutputCollective) ;
+    settings.saveToDamarisHDF5 = EWOMS_GET_PARAM(TypeTag, bool, DamarisSaveToHdf);
+    settings.pythonFilename = EWOMS_GET_PARAM(TypeTag, std::string, DamarisPythonScript);
+    settings.paraviewPythonFilename = EWOMS_GET_PARAM(TypeTag, std::string, DamarisPythonParaviewScript);
+    settings.damarisSimName = EWOMS_GET_PARAM(TypeTag, std::string, DamarisSimName);
+    settings.nDamarisCores = EWOMS_GET_PARAM(TypeTag, int, DamarisDedicatedCores);
+    settings.nDamarisNodes = EWOMS_GET_PARAM(TypeTag, int, DamarisDedicatedNodes);
+    settings.shmemSizeBytes = EWOMS_GET_PARAM(TypeTag, long, DamarisSharedMemeorySizeBytes);
+    settings.damarisLogLevel = EWOMS_GET_PARAM(TypeTag, std::string, DamarisLogLevel);
+
+    return settings.getKeywords(comm, OutputDir);
+}
 
 } // namespace Opm::DamarisOutput
 

--- a/opm/simulators/utils/DamarisOutputModule.cpp
+++ b/opm/simulators/utils/DamarisOutputModule.cpp
@@ -36,7 +36,6 @@ namespace Opm::DamarisOutput
 
 std::string initDamarisXmlFile(); // Defined in initDamarisXMLFile.cpp, to avoid messing up this file.
 
-
  // Initialize Damaris by filling in th XML file and storing it in the chosen directory
 void
 initializeDamaris(MPI_Comm comm, int mpiRank, std::map<std::string, std::string>& find_replace_map )
@@ -56,14 +55,14 @@ initializeDamaris(MPI_Comm comm, int mpiRank, std::map<std::string, std::string>
                                                mpiRank, cs_damaris_xml_file, damaris_error_string(dam_err_) ));
         }
     } else {
-         // Prepare the XML file
+        // Prepare the XML file
         std::string damaris_config_xml = initDamarisXmlFile();  // This is the template for a Damaris XML file
         damaris::model::ModifyModel myMod = damaris::model::ModifyModel(damaris_config_xml);
         // The map will make it precise the output directory and FileMode (either FilePerCore or Collective storage)
         // The map file find all occurences of the string in position 1 and replace it/them with string in position 2
         // std::map<std::string, std::string> find_replace_map = DamarisKeywords(outputDir, enableDamarisOutputCollective);
         myMod.RepalceWithRegEx(find_replace_map);
-        
+
         std::string outputDir = find_replace_map["_PATH_REGEX_"] ;
         std::string damaris_xml_filename_str = outputDir + "/damaris_config.xml";
 
@@ -79,7 +78,5 @@ initializeDamaris(MPI_Comm comm, int mpiRank, std::map<std::string, std::string>
         }
     }
 }
-
-
 
 } // namespace Opm::DamarisOutput

--- a/opm/simulators/utils/DamarisOutputModule.hpp
+++ b/opm/simulators/utils/DamarisOutputModule.hpp
@@ -41,7 +41,13 @@ namespace Opm::DamarisOutput
 {
  // Initialize an XML file
  std::string initDamarisXmlFile();
- // Initialize Damaris by filling in th XML file and storing it in the chosen directory
+ 
+/**
+*   Initialize Damaris by either:
+*  1/ Filling in a templated XML file and storing it in the chosen directory (output directory)
+*  2/ Reading a file specified by the environment variable FLOW_DAMARIS_XML_FILE 
+*  
+*/
  void initializeDamaris(MPI_Comm comm, int mpiRank, std::map<std::string, std::string>& find_replace_map );
 
 } // namespace Opm::DamarisOutput

--- a/opm/simulators/utils/DamarisOutputModule.hpp
+++ b/opm/simulators/utils/DamarisOutputModule.hpp
@@ -18,7 +18,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <opm/common/OpmLog/OpmLog.hpp>
+
+#include <limits>
+#include <stdexcept>
 #include <string>
+
+#include <fmt/format.h>
+#include <mpi.h>
 #include <Damaris.h>
 #include <opm/simulators/utils/ParallelCommunication.hpp>
 
@@ -34,7 +41,7 @@ namespace Opm::DamarisOutput
 {
  // Initialize an XML file
  std::string initDamarisXmlFile();
- // Initialize Damaris by filling in th XML file and stroring it in the chosed directory
- void initializeDamaris(MPI_Comm comm, int mpiRank, std::string OutputDir, bool enableDamarisOutputCollective);
+ // Initialize Damaris by filling in th XML file and storing it in the chosen directory
+ void initializeDamaris(MPI_Comm comm, int mpiRank, std::map<std::string, std::string>& find_replace_map );
 
 } // namespace Opm::DamarisOutput

--- a/opm/simulators/utils/DamarisVar.hpp
+++ b/opm/simulators/utils/DamarisVar.hpp
@@ -1,0 +1,620 @@
+/*
+  Copyright 2023 Inria, Bretagne–Atlantique Research Center
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DAMARIS_MODEL_DATA_HPP
+#define DAMARIS_MODEL_DATA_HPP
+
+#include <string>
+#include <iostream>
+#include <sstream>
+#include <cassert>
+#include <typeinfo>
+
+#include <Damaris.h>
+
+
+/*
+    File: DamarisVar.hpp
+    Author: Joshua Bowden, Inria
+    Date: 06/02/2023
+    The DamarisVar class can be used to allocate memory in the Damaris shared memory region and a user can supply
+    the data required for the variable to pass to Damaris.
+*/
+
+
+namespace Opm
+{
+    namespace DamarisOutput
+    {
+    /**
+    *  This class contains the extra elements that need to be part of a Damaris <variable> type. 
+    *  They are simple string values that may reference other XML elements (and could be checked for existence etc.)
+    */
+    class DamarisVarXMLAttributes {
+            std::string layout_ ;         //!< Reference string to the XML attribute layout being used to describe the shape of the variable. This is a required attribute.
+            std::string mesh_ ;           //!< Reference string to the XML attribute mesh element - the mesh is used to define the spatial layout of data and is used by visualization backends to generate 2D/3D model images
+            std::string type_ ;           //!< Reference string to the XML attribute type of data - "scalar" or "vector" (others tensor maybe). TODO: check if this attribute is used by the Damaris library anywhere.
+            std::string visualizable_ ;   //!< Reference string to the XML attribute property that data can be sent to vis backends - "true" | "false"
+            std::string unit_ ;           //!< Reference string to the XML attribute element denoting unit of the data
+            std::string time_varying_ ;   //!< Reference string to the XML attribute to indicate if data changes over iterations - "true" | "false"
+            std::string centering_ ;      //!< Reference string to the XML attribute to indicate where data aligns on a mesh - "zonal" | "nodal"
+            std::string store_ ;          //!< Reference string to the XML attribute to indicate if data should be passed to I/O store (e.g. to HDF5 plugin)
+            std::string script_ ;         //!< Reference string to the XML attribute to indicate if data should be published as Python NumPy data
+            std::string select_mem_ ;      //!< Reference string to the XML attribute select. The referenced variables data is used as indices to  select dat from memory to reorder output in the collective HDF5 data writer (Damaris version 1.8+)
+            std::string select_file_ ;     //!< Reference string to the XML attribute select. The referenced variables data is used as indices to select positions in the dataset file to reorder output in the collective HDF5 data writer (Damaris version 1.8+)
+            std::string select_subset_ ;   //!< Reference string to the XML attribute select. Used to specify the output dataset shape and how much data each rank contributes to it and the global offsets to the ranks data (Damaris version 1.8+)
+
+        public:
+            DamarisVarXMLAttributes(){
+                // Additional data needed to complete an XML <variable> element
+                layout_ = "" ;
+                mesh_ = "" ;
+                type_ = "scalar" ;  // This is probably not needed as vector data is defined using the Layout paramter. Could be useful for cross checking
+                visualizable_ = "false";
+                unit_ = "" ;
+                time_varying_ = "true";
+                centering_ = "zonal" ;
+                store_ = "" ;
+                script_ = "" ;
+                select_mem_ = "" ;
+            }
+
+            /**
+            * Creates the XML representation of the variable from the available strings
+            */
+            std::string ReturnXMLForVariable ( void )
+            {
+                std::ostringstream  var_sstr ;
+
+                var_sstr << " layout=\"" << this->layout_ << "\"" ;
+                if (this->mesh_ != "") var_sstr  << " mesh=\"" << this->mesh_ << "\"" ;
+                if (this->type_ != "") var_sstr  << " type=\"" << this->type_ << "\"" ;
+                if (this->visualizable_ != "") var_sstr  << " visualizable=\"" << this->visualizable_ << "\"" ;
+                if (this->unit_ != "") var_sstr  << " unit=\"" << this->unit_ << "\"" ;
+                if (this->time_varying_ != "") var_sstr  << " time_varying=\"" << this->time_varying_ << "\"" ;
+                if (this->centering_ != "") var_sstr  << " centering=\"" << this->centering_ << "\"" ;
+                if (this->store_ != "") var_sstr  << " store=\"" << this->store_ << "\"" ;
+                if (this->script_ != "") var_sstr  << " script=\"" << this->script_  << "\"" ;
+                if (this->select_mem_ != "") var_sstr  << " select-mem=\"" << this->select_mem_ << "\"" ;
+                if (this->select_file_ != "") var_sstr  << " select-file=\"" << this->select_file_ << "\"" ;
+                if (this->select_subset_ != "") var_sstr  << " select-subset=\"" << this->select_subset_ << "\"" ;
+
+                return (var_sstr.str()) ;
+            }
+    } ;
+
+    class DamarisVarBase { 
+        public:
+            // DamarisVarBase(int dims, std::vector<std::string>& param_names, std::string& variable_name, int rank=0)  = 0  ; 
+            virtual ~DamarisVarBase( void )  {}  ;
+
+            virtual void PrintError ( void ) = 0  ;
+            virtual bool HasError( void ) = 0  ;
+            // virtual void SetDamarisParameterAndShmem( std::vector<int>& paramSizeVal )  = 0  ;
+            virtual void SetDamarisParameterAndShmem( std::vector<int> paramSizeVal )  = 0  ;
+            virtual void SetDamarisParameter( std::vector<int>& paramSizeVal )  = 0  ;
+            virtual void SetDamarisPosition(  std::vector<int64_t> positionsVals ) = 0  ;
+            virtual void SetPointersToDamarisShmem( void ) = 0  ;
+            virtual void CommitVariableDamarisShmem( void ) = 0 ;
+            virtual void ClearVariableDamarisShmem( void ) = 0  ;
+            // virtual void * data_ptr( void ) = 0  ;
+            virtual std::string & variable_name( void ) = 0  ;
+
+
+
+    };  // class DamarisVar
+
+    /**
+    *  class to store a Damaris variable representation for the XML file (can be used with /ref class DamarisKeywords).
+    *
+    *  It is thought that the details stored in the object can be used to pass into an XML generation function e.g. DamarisKeywords
+    *
+    *  Should be instantiated with something like the following:
+    *  // The following needs to be defined in the Damaris XML file: 
+    *  // <parameter name="n_elements_mpi_local"     type="int" value="1" />
+    *  // <layout    name="mpi_layout"    type="int" dimensions="n_elements_mpi_local"   comment="MPI elements layout"  />
+    *  // <variable name="MPI_RANK"  layout="mpi_layout"   type="scalar"  visualizable="true" mesh="unstructured_mesh" unit="rank"  centering="zonal"
+    *  //                                                   store="#" time-varying="false"  script="_PYTHON_XML_NAME_" comment="The cells MPI rank"/>
+    *  damaris::model::DamarisVar<int>  dam_var = new damaris::model::DamarisVar<int>(1, {std::string("n_connectivity_ph")}, std::string("topologies/topo/elements/connectivity"), rank_) ;
+    *  dam_var->SetDamarisParameterAndShmem( { geomData.getNCorners() } ) ;
+    *
+    *  int * shmem_mpi_ptr = dam_var->data_ptr() ;
+    *  // Fill the created memory area
+    *  for (int i = 0 ; i < ; i++ )
+    *  {
+    *      shmem_mpi_ptr[i] = rank_ ;
+    *  }
+    *  delete dam_var ;  // this tells Damaris that the shared memory that it supplied is at its disposal. It will print error messages too.
+    *
+    */
+    template <typename T>
+    class DamarisVar :
+         public DamarisVarBase {
+            int   dims_ ;
+            int   num_params_ ;       //!< Each paramater name string will need a value and they are set in SetDamarisParameter()
+            int  * param_sizes_ ;     //!< The value for any paramaters that are being used to describe the size of the variables data array
+            int64_t * positions_ ;    //!< The offsets into the array that the data in the Variable starts from for this rank.
+            int   rank_ ;             //!< Rank of process - used for error reporting.
+            bool  paramaters_set_ ;   //!< set to true after SetDamarisParameter() is call to ensure the variable has correct size for memory allocation in SetPointersToDamarisShmem()
+
+            std::vector<std::string> param_names_ ;  //!< Contains one paramater name for each paramater that a variable depends on (via it's Layout)
+            std::string variable_name_ ;         //!< Reference string to the XML attribute name of the variable.
+
+            int dam_err_ ;                       //!<  Set to != DAMARIS_OK if a Daamris error was returned by a Damaris API function call
+            bool has_error_ ;
+            std::ostringstream  dam_err_sstr_ ;  //!< Use dam_err_sstr.str() to return an error string describing detected error
+
+            DamarisVarXMLAttributes xml_attributes_ ; //!< The extra elements that need to be part of a Damaris <variable> type. They are simple string values that may reference other XML elements (and could be checked for existence etc.)
+
+            T * data_ptr_ ;                      //!< This pointer will be mapped to the Damaris shared memory area for the variable in the SetPointersToDamarisShmem() method. The type T will match the Layout type
+
+        public:
+
+            /**
+            * Constructor - sets private data values and dos not initialise the shared memory area.
+            *
+            * Two usages:
+            *         Example XML definition:
+            *          <parameter name="my_param_name1"     type="int" value="1" />
+            *          <parameter name="my_param_name2"     type="int" value="1" />
+            *          <layout    name="my_layout"    type="int" dimensions="my_param_name1,my_param_name2"   comment="This is a 2D variable"  />
+            *          <variable name="MYVARNAME"  layout="my_layout"  visualizable="true"/>
+            *
+            *          1/ The variable's layout needs to be initialised via parameters :
+            *          // Create the DamarisVar object:
+            *          damaris::model::DamarisVar<int>  MYVARNAME_2d = new damaris::model::DamarisVar<int>(2, {std::string("my_param_name1"), std::string("my_param_name2")}, std::string("MYVARNAME"), rank_) ;
+            *           // Set the paramter sizes
+            *          MYVARNAME_2d->SetDamarisParameterAndShmem( {25, 100 } } ;  // sets the paramaters  (here, my_param_name1 == 25 and my_param_name2 == 100)
+            *          // Get a pointer to the memeory and use it
+            *          T * mymemory = MYVARNAME_2d->data_ptr() ;
+            *          ... write data to mymemory ....
+            *          delete MYVARNAME_2d ;
+            * or,
+            *  2/  The variable's layout has been initialised via parameters in another variable (i.e. "my_param_name1" and "my_param_name2" have been previously set in the code)
+            *          // Create the DamarisVar object:
+            *          damaris::model::DamarisVar<int>  MYVARNAME_2d = new damaris::model::DamarisVar<int>(2, {std::string("my_param_name1"), std::string("my_param_name2")}, std::string("MYVARNAME"), rank_) ;
+            *          // explicitly state that the paramater values have been set somewhere else in the code previously.
+            *          MYVARNAME_2d->ParameterIsSet() ;
+            *          MYVARNAME_2d->SetPointersToDamarisShmem() 
+            *          // Get a pointer to the memeory and use it
+            *          T * mymemory = MYVARNAME_2d->data_ptr() ;
+            *          ... write data to mymemory ....
+            *          delete MYVARNAME_2d ;
+            * 
+            *  /param [IN] dims           Used to check that the inputs to SetDamarisPosition() have the same number of values - one value for each dimension
+            *  /param [IN] param_names    The name the Damaris paramaters. These names (in typical use) control a Damaris variables size (names are defined in the Damaris XML file).
+            *  /param [IN] variable_name  The name of the Damaris variable (defined in the Dmaaris XML file)
+            *  /param [IN] rank           The rank of the process. Used for error output.
+            */
+            DamarisVar(int dims, std::vector<std::string> param_names, std::string variable_name, int rank) 
+            : dims_( dims ),
+              param_names_( param_names ),
+              variable_name_( variable_name ),
+              rank_(rank)
+            {
+                dam_err_ = DAMARIS_OK ;
+                
+                assert( param_names_.size() == dims ) ;
+                assert( dims > 0 ) ;
+                
+                // Check that our template type T matches out Damaris XML <layout> type
+                if ( !TestType(variable_name) ) {
+                    std::exit(-1) ;
+                }
+
+                num_params_ = param_names_.size() ; 
+                param_sizes_ = new int(num_params_) ;
+                positions_ = new int64_t(dims) ;
+
+                data_ptr_ = nullptr ;
+                paramaters_set_ = false ;
+                has_error_ = false ;
+            }
+
+            /**
+            *  Constructor - Sets private data values and also initialises the Damaris shared memory area for writing (and reading) 
+            *                by specifying the values for the variables parameters . i.e. makes the data_ptr() 
+            * 
+            *  Example use:
+            *         Example XML definition:
+            *          <parameter name="my_param_name1"     type="int" value="1" />
+            *          <parameter name="my_param_name2"     type="int" value="1" />
+            *          <layout    name="my_layout"    type="int" dimensions="my_param_name1,my_param_name2"   comment="This is a 2D variable"  />
+            *          <variable name="MYVARNAME"  layout="my_layout"  visualizable="true"/>
+            *  // The paramaters are intialized in the constructor code
+            *  damaris::model::DamarisVar<int>  MYVARNAME_2d = new damaris::model::DamarisVar<int>(2, {std::string("my_param_name1"), std::string("my_param_name2")}, {100, 25},  std::string("MYVARNAME"), rank_) ;
+            *  T * mymemory = MYVARNAME_2d->data_ptr() ;
+            *  ... write data to mymemory ....
+            *  delete MYVARNAME_2d ;
+            * 
+            *  /param [IN] dims           Used to check that the inputs to SetDamarisPosition() have the same number of values - one value for each dimension
+            *  /param [IN] param_names    The name the Damaris paramaters. These names (in typical use) control a Damaris variables size (names are defined in the Damaris XML file).
+            *  /param [IN] param_values   The values of the paramaters - this defines how much memory we will have access to in the shared memory area (on the current and ongoing iterations, until later modified to new values)
+            *  /param [IN] variable_name  The name of the Damaris variable (defined in the Dmaaris XML file)
+            *  /param [IN] rank           The rank of the process. Used for error output.
+            */
+            DamarisVar(int dims, std::vector<std::string> param_names, std::vector<int> param_values, std::string variable_name, int rank) 
+            : dims_( dims ),
+              param_names_( param_names ),
+              variable_name_( variable_name ),
+              rank_(rank)
+            {
+                dam_err_ = DAMARIS_OK ;
+                
+                assert( param_names_.size() == dims ) ;
+                assert( dims > 0 ) ;
+                
+                // Check that our template type T matches out Damaris XML <layout> type
+                if ( !TestType(variable_name) ) {
+                    std::exit(-1) ;
+                }
+
+                num_params_ = param_names_.size() ; 
+                param_sizes_ = new int(num_params_) ;
+                positions_ = new int64_t(dims) ;
+
+                data_ptr_ = nullptr ;
+                paramaters_set_ = false ;
+                has_error_ = false ;
+                
+                SetDamarisParameterAndShmem( param_values ) ;  // Initialise the memory size in the constructor.
+            }
+
+            ~DamarisVar( void ) {
+                  delete [] param_sizes_ ;
+                  delete [] positions_ ;
+                  if (data_ptr_ != nullptr) 
+                  {
+                      CommitVariableDamarisShmem() ; 
+                      ClearVariableDamarisShmem() ; 
+                  }
+                  if (this->HasError()) 
+                      PrintError() ; // flush out any error messages
+            }
+
+            /**
+            *  Method to check that the template paramater T is the same as the requested type for the variable in the XML file
+            */
+            bool TestType(std::string variable_name)
+            {
+                bool resbool = true ;
+                // This gets the type of the Damaris XML <variable>'s <layout>
+                DAMARIS_TYPE_STR vartype ;
+                dam_err_ = damaris_get_type(variable_name.c_str(), &vartype) ;
+                if (dam_err_ != DAMARIS_OK) {
+                    dam_err_sstr_ << "  ERROR rankDamarisVar::DamarisVar ()  damaris_get_type(\"" 
+                                     << variable_name_ << "\", vartype);  Damaris error = " <<  damaris_error_string(dam_err_) << std::endl ;
+                    has_error_ = true ;
+                    return( false ) ;
+                }
+                T test_id;
+                const std::type_info& t1 = typeid(test_id) ;
+                
+                if (vartype == DAMARIS_TYPE_DOUBLE)
+                {
+                    double td = 0.0 ;
+                    const std::type_info& t2 = typeid(td) ;
+                    if (t1 != t2) {
+                        OutputErrorAndAssert(variable_name, t1.name(), t2.name()) ;
+                        resbool = false ;
+                    }
+                } 
+                else if (vartype == DAMARIS_TYPE_FLOAT) 
+                {
+                    float td = 0.0f ;
+                    const std::type_info& t2 = typeid(td) ;
+                    if (t1 != t2) {
+                        OutputErrorAndAssert(variable_name, t1.name(), t2.name()) ;
+                        resbool = false ;
+                    }
+                } 
+                else if (vartype == DAMARIS_TYPE_CHAR)
+                {
+                    char td = 0;
+                    const std::type_info& t2 = typeid(td) ;
+                    if (t1 != t2) {
+                        OutputErrorAndAssert(variable_name, t1.name(), t2.name()) ;
+                        resbool = false ;
+                    }
+                }
+                else if (vartype == DAMARIS_TYPE_UCHAR)
+                {
+                    unsigned char td = 0;
+                    const std::type_info& t2 = typeid(td) ;
+                    if (t1 != t2) {
+                        OutputErrorAndAssert(variable_name, t1.name(), t2.name()) ;
+                        resbool = false ;
+                    }
+                }
+                else if (vartype == DAMARIS_TYPE_SHORT)
+                {
+                    short td = 0;
+                    const std::type_info& t2 = typeid(td) ;
+                    if (t1 != t2) {
+                        OutputErrorAndAssert(variable_name, t1.name(), t2.name()) ;
+                        resbool = false ;
+                    }
+                }
+                else if (vartype == DAMARIS_TYPE_USHORT)
+                {
+                    unsigned short td = 0;
+                    const std::type_info& t2 = typeid(td) ;
+                    if (t1 != t2) {
+                        OutputErrorAndAssert(variable_name, t1.name(), t2.name()) ;
+                        resbool = false ;
+                    }
+                }
+                else if (vartype == DAMARIS_TYPE_INT)
+                {
+                    int td = 0;
+                    const std::type_info& t2 = typeid(td) ;
+                    if (t1 != t2) {
+                        OutputErrorAndAssert(variable_name, t1.name(), t2.name()) ;
+                        resbool = false ;
+                    }
+                }
+                else if (vartype == DAMARIS_TYPE_UINT)
+                {
+                    unsigned int td = 0;
+                    const std::type_info& t2 = typeid(td) ;
+                    if (t1 != t2) {
+                        OutputErrorAndAssert(variable_name, t1.name(), t2.name()) ;
+                        resbool = false ;
+                    }
+                }
+                else if (vartype == DAMARIS_TYPE_LONG)
+                {
+                    long td = 0;
+                    const std::type_info& t2 = typeid(td) ;
+                    if (t1 != t2) {
+                        OutputErrorAndAssert(variable_name, t1.name(), t2.name()) ;
+                        resbool = false ;
+                    }
+                }
+                else if (vartype == DAMARIS_TYPE_ULONG)
+                {
+                    unsigned long td = 0;
+                    const std::type_info& t2 = typeid(td) ;
+                    if (t1 != t2) {
+                        OutputErrorAndAssert(variable_name, t1.name(), t2.name()) ;
+                        resbool = false ;
+                    }
+                }
+                else if (vartype == DAMARIS_TYPE_UNDEFINED)
+                {
+                    std::cerr << "ERROR rank =" << rank_ << " : DamarisVar::DamarisVar()::  \"" << variable_name << "\" has type DAMARIS_TYPE_UNDEFINED"<< std::endl ;
+                    resbool = false ;
+                } 
+                else 
+                {
+                    std::cerr << "ERROR rank =" << rank_ << " : DamarisVar::DamarisVar():: \"" << variable_name << "\" is not of available type "<< std::endl ;
+                    resbool = false ;
+                }
+                
+                return resbool ;
+            }
+
+            /**
+            *  Allow a user to indicate that the Damaris variable has allocated a size -
+             * This method is usefull as a single paramater can control one or more layouts and
+             * a single layout can describe the size of multiple <variable> elements.
+             * i.e. The current variable has had it's paramater(s) set through via another variable.
+            */
+            void ParameterIsSet() 
+            {
+                paramaters_set_ = true ;
+            }
+
+            void PrintError ( void )
+            {
+                std::cerr << dam_err_sstr_.str() ;
+            }
+
+            bool HasError( void )
+            {
+               return (has_error_) ;
+            }
+
+            /**
+            *  Returns the data pointer to shared memory, or nullptr if it has not been allocated
+            */
+            T * data_ptr( void ) 
+            {
+               return (data_ptr_) ;
+            }
+
+            std::string & variable_name( void )
+            {
+               return (variable_name_) ;
+            }
+
+             /**
+            * Creates the XML representation of the variable from the available strings
+            */
+            std::string ReturnXMLForVariable ( void )
+            {
+                std::ostringstream  var_sstr ;
+
+                var_sstr << "<variable " << " name=\"" << variable_name_ << "\"" ;
+                var_sstr << xml_attributes_.ReturnXMLForVariable() ;
+                var_sstr << " /> " ;
+
+                return var_sstr.str() ;
+            }
+
+            /**
+            *  Method to set the Damaris paramater values and set the shmem region \ref data_ptr_
+            *
+            *  /param [IN] paramSizeVal : A vector of values to set the Damaris paramters to. One element per param_names_ string
+            *
+            *
+            */
+            void SetDamarisParameterAndShmem( std::vector<int> paramSizeVal ) 
+            {
+                this->SetDamarisParameter( paramSizeVal )  ;
+                this->SetPointersToDamarisShmem() ;
+            }
+
+            /**
+            *  Method to set the Damaris paramater values.
+            *
+            *  /param [IN] paramSizeVal : An pointer to a value or array of values to set. One element per param_names_ string
+            *
+            *  /implicit                : Implicitly uses the array of paramater names: \ref param_names_
+            */
+            void SetDamarisParameter( std::vector<int>& paramSizeVal ) 
+            {
+                assert(paramSizeVal.size() == num_params_) ;
+
+                bool resbool = true ;
+                for (int varnum = 0 ; varnum < num_params_ ; varnum++)
+                {
+                    param_sizes_[varnum] = paramSizeVal[varnum] ;
+
+                    dam_err_ = damaris_parameter_set(param_names_[varnum].c_str(), &paramSizeVal[varnum], sizeof(int));
+                    if (dam_err_ != DAMARIS_OK) {
+                        dam_err_sstr_ << "  ERROR rank =" << rank_ << " : class DamarisVar : damaris_parameter_set(\"" << param_names_[varnum] 
+                                          << "\", paramSizeVal, sizeof(int));  Damaris error = " <<  damaris_error_string(dam_err_) << std::endl ;
+                        resbool = false ;
+                        has_error_ = true ;
+                    }
+                }
+                if (resbool == true) 
+                    paramaters_set_ = true ;
+            }
+
+            /**
+            *  Method to set the Damaris position values.
+            *
+            *  /param [IN] positionsVals : An pointer to a value or array of values to set as the offset into the array. 
+            *                              One element per dimension (one value for each dim_)
+            *
+            *  /implicit                 : Implicitly uses the variable name: \ref variable_name_
+            */
+            void SetDamarisPosition( std::vector<int64_t> positionsVals ) 
+            {
+                assert(positionsVals.size() == dims_) ;
+
+                for (int pos_dim = 0 ; pos_dim < dims_ ; pos_dim++)
+                {
+                    positions_[pos_dim] = positionsVals[pos_dim] ;
+                }
+                dam_err_ = damaris_set_position(variable_name_.c_str(), positionsVals.data());
+                if (dam_err_ != DAMARIS_OK) {
+                    dam_err_sstr_ << "  ERROR rank =" << rank_ << " : class DamarisVar : damaris_set_position(\"" 
+                                     << variable_name_ << "\", positionsVals);  Damaris error = " <<  damaris_error_string(dam_err_) << std::endl ;
+                    has_error_ = true ;
+                }
+            }
+
+            /**
+            *  Method to set the Damaris paramater values.
+            *
+            *  /implicit                : Implicitly uses the Damaris variable name string  \ref variable_name_
+            *  /implicit                : Implicitly uses the class data element : \ref data_ptr_
+            */
+            void SetPointersToDamarisShmem( void )
+            {
+                if (paramaters_set_ == true )
+                {
+                    // Allocate memory in the shared memory section... 
+                    dam_err_ = damaris_alloc(variable_name_.c_str(), (void **) &data_ptr_) ;
+                    if (dam_err_ != DAMARIS_OK) {
+                        dam_err_sstr_ << "  ERROR rank =" << rank_ << " : class DamarisVar : damaris_alloc(\"" 
+                                      << variable_name_ <<"\", (void **) &ret_ptr)" << ", Damaris error = " <<  damaris_error_string(dam_err_) << std::endl ;
+                        has_error_ = true ;
+                    }
+                } else {
+                    dam_err_ = -1 ;
+                    dam_err_sstr_ << "ERROR rank =" << rank_  << " : class DamarisVar : SetDamarisParameter() should be called first so as to define the size of the memory block required for variable : " << variable_name_ << std::endl ;
+                    has_error_ = true ;
+                }
+            }
+
+            void SetPointersToDamarisShmem( T ** ptr_in )
+            {
+                if (paramaters_set_ == true )
+                {
+                    T * temp_ptr ;
+                    // Allocate memory in the shared memory section... 
+                    dam_err_ = damaris_alloc(variable_name_.c_str(), (void **) &temp_ptr) ;
+                    if (dam_err_ != DAMARIS_OK) {
+                        dam_err_sstr_ << "  ERROR rank =" << rank_ << " : class DamarisVar : damaris_alloc(\"" 
+                                          << variable_name_ <<"\", (void **) &ret_ptr)" << ", Damaris error = " <<  damaris_error_string(dam_err_) << std::endl ;
+                        has_error_ = true ;
+                    }
+
+                    *ptr_in = temp_ptr ;
+                    data_ptr_ = temp_ptr ;
+                } else {
+                    dam_err_ = -1 ;
+                    dam_err_sstr_ << "  ERROR rank =" << rank_  << " : class DamarisVar : SetDamarisParameter() should be called first so as to define the size of the memory block required for variable : " << variable_name_ << std::endl ;
+                    has_error_ = true ;
+                }
+            }
+
+            /**
+            *  Method to commit the memory of the data written to the Damaris variable - 
+            *  Indicates that we will not write any more data to \ref data_ptr_
+            *
+            *  /implicit                : Implicitly uses the variable name string  \ref variable_name_
+            */
+            void CommitVariableDamarisShmem( void )
+            {
+                // Signal to Damaris we are done writing data for this iteration
+                dam_err_ = damaris_commit (variable_name_.c_str()) ;
+                if (dam_err_ != DAMARIS_OK) {
+                    dam_err_sstr_ << "  ERROR rank =" << rank_ << " : class DamarisVar : damaris_commit(\"" 
+                                      << variable_name_ <<"\")"  << ", Damaris error = " <<  damaris_error_string(dam_err_) << std::endl ;
+                    has_error_ = true ;
+                }
+            }
+
+            /**
+            *  Method to release the memory of the data written to the Damaris variable - 
+            *  Indicates that Damaris may take control of the shared memory area that was used for the variable \ref data_ptr_
+            *
+            *  /implicit                : Implicitly uses the variable name string  \ref variable_name_
+            */
+            void ClearVariableDamarisShmem( void )
+            {
+                // Signal to Damaris it has complete charge of the memory area
+                dam_err_ = damaris_clear(variable_name_.c_str()) ;
+                if (dam_err_ != DAMARIS_OK) {
+                    dam_err_sstr_ << "  ERROR rank =" << rank_ << " : class DamarisVar : damaris_clear(\"" 
+                                      << variable_name_ << "\")"  << ", Damaris error = " <<  damaris_error_string(dam_err_) << std::endl ;
+                    has_error_ = true ;
+                }
+                data_ptr_ = nullptr ;
+            }
+        private:
+            void OutputErrorAndAssert(std::string& var_name, std::string type_name1, std::string type_name2)
+            {
+                dam_err_sstr_ << "ERROR rank =" << rank_ << " : DamarisVar::DamarisVar () variable_name_: \"" << var_name 
+                    << "\" The template type of Type of DamarisVar<T> in the code: " << type_name1 << " does not match type in XML (float)" << std::endl ;
+                PrintError() ;
+                assert( type_name1 == type_name2  ) ;
+            }
+    };  // class DamarisVar
+
+    } // namespace DamarisOutput
+
+} // namespace OPM
+
+#endif 

--- a/opm/simulators/utils/GridDataOutput.hpp
+++ b/opm/simulators/utils/GridDataOutput.hpp
@@ -1,0 +1,455 @@
+// -*- tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+// vi: set et ts=4 sw=2 sts=2:
+/*
+  Copyright 2023 Inria, Bretagne–Atlantique Research Center
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_SIM_MESH_DATA2_HPP
+#define OPM_SIM_MESH_DATA2_HPP
+
+#include <sstream>
+#include <dune/grid/common/rangegenerators.hh>
+#include <dune/grid/io/file/vtk/common.hh>
+
+/** @file
+    @brief Allows model geometry data to be passed to external code - via a copy direct to input pointers. 
+    
+    This data extractor provides the full set of vertices (corresponding to Dune::Partition::all) and then 
+    allows a user to specify Dune sub-partitions to get the references into the vertex array and element 
+    (aka cell) types for the sub-partition. This allows the full set of verticies to be reused for 
+    visualisation of the various sub-partitions, at the expense of copying all the vertices. Typically
+    a user is interested in the interiorBoarder elements which make use of the bulk (~80%) of the vertices.
+    This saves having to renumber the indexes to the vertices for the sub-partitions.
+    The vertex data can be retrieved as seperate x, y and z arrays, or as a single array of structures, 
+    or as a single structure of arrays based 
+
+
+    Example:
+        // From the opm-simulators repository
+        #include <opm/simulators/utils/GridDataOutput.hpp>
+        
+        // N.B. does not seem to be able to be allocated with new operator.
+        Opm::GridDataOutput::SimMeshDataAccessor geomData(gridView,  Dune::Partition::interior ) ;
+
+        geomData.printGridDetails() ;
+        
+        // example using seperate x, y and z arrays
+        int nvert = geomData.getNVertices() ;
+        double * x_vert = new double[nvert] ;
+        double * y_vert = new double[nvert] ;
+        double * z_vert = new double[nvert] ;
+        geomData.writeGridPoints(x_vert,y_vert,z_vert) ;
+
+        ... do something with vertex data x_vert, y_vert and z_vert ....
+
+        free [] x_vert;
+        free [] y_vert;
+        free [] z_vert;
+        
+        // example using AOS 
+        double * xyz_vert_aos = new double[nvert*3] ;
+        geomData.writeGridPoints_SOA(xyz_vert_aos) ;
+
+        ... do something with vertex data xyz_vert_aos....
+
+        free [] xyz_vert_aos;
+        
+
+*/
+
+namespace Opm::GridDataOutput
+{
+   /**
+   * Allows selection of order of verticies in writeConnectivity()
+   */
+  enum ConnectivityVertexOrder { DUNE = 0 , VTK = 1 } ;
+
+  template< class GridView, unsigned int partitions >
+  class SimMeshDataAccessor {
+  public:
+    /**
+     * @brief Construct a SimMeshDataAccessor working on a specific GridView and specialize to a Dune::PartitionSet<>.
+     *
+     * @param gridView The gridView 
+     * @param PartitionSet<> the set of cells from which to extract geometric data
+     *
+     *  The PartitionSet of the data can be specified from one of:
+     *   Dune::Partitions::all
+     *   Dune::Partitions::interior
+     *   Dune::Partitions::border
+     *   Dune::Partitions::overlap
+     *   Dune::Partitions::front
+     *   Dune::Partitions::ghost
+     *   Dune::Partitions::interiorBorder
+     *   Dune::Partitions::interiorBorderOverlap
+     *   Dune::Partitions::interiorBorderOverlapFront
+     *   Dune::Partitions::all
+     *
+     * N.B. To visualise 'field' data on the extracted grid mesh then the field variable
+     *       should contain at least as many vlaues as the mesh has cells  (ncells_) or vertices (nvertices_)
+     *       depending on if data is cell centred or vertex centred, respectively.
+     *
+     *  As we are templated on the Dune::PartitionSet<partitions>, values for ncorners_, nvertices_ and ncells_ cannot change
+     *
+     *  This class does not work with grids containing polyhedral cells (well, it has not been tested
+     *  with this kind of grid data). The user should call polyhedralCellPresent() to test if polyhedral 
+     *  cells are present and decide what they want to do before copying data using the data accessor methods.
+     */
+    explicit SimMeshDataAccessor ( const GridView &gridView,  
+                            Dune::PartitionSet<partitions>  dunePartition)
+        : gridView_( gridView ),
+          dunePartition_(dunePartition)
+    {
+        dimw_ = GridView::dimension ; // this is an enum
+        partition_value_ = dunePartition.value ;
+        countEntities() ;
+    }
+
+    //! destructor
+    ~SimMeshDataAccessor ()
+    {
+    }
+
+     /**
+       Checks for cells that have polyhedral type within the current partition of cells
+       
+       Returns true if a polyhedral sell is found. If this is the case then this partition 
+       is not going to be available for visualisation as this class does not yet handle 
+       polyhedral cells.
+    */
+    bool polyhedralCellPresent() 
+    {
+        for (const auto& cit :  elements(gridView_, dunePartition_))
+        {
+            auto  corner_geom = cit.geometry() ;
+            if( Dune::VTK::geometryType( corner_geom.type() ) == Dune::VTK::polyhedron )
+            {
+                return true ;
+            }
+       } 
+       return false;
+    }
+
+    /** 
+        Count the vertices, cells and corners.
+
+        Count all the vertices ( the Dune::Partitions::all partition ) as then we do not need to renumber
+        the vertices as all the subsets use references to the full set.
+    */ 
+    void countEntities(  )
+    {
+        // We include all the vertices for this ranks partition
+        const auto& vert_partition_it = vertices(gridView_, Dune::Partitions::all);
+        nvertices_ = std::distance(vert_partition_it.begin(), vert_partition_it.end());
+
+        const auto& cell_partition_it = elements(gridView_, dunePartition_);
+        ncells_ = std::distance(cell_partition_it.begin(), cell_partition_it.end());
+
+        ncorners_ = 0 ;
+        for (const auto& cit : cell_partition_it)
+        {
+            auto  corner_geom = cit.geometry() ;
+            ncorners_ += corner_geom.corners() ;
+        }
+    }
+
+     /**
+       Write the positions of vertices - directly to the pointers given in paramaters 
+
+       Returns the number of vertices written
+    */
+    template <typename T> 
+    long  writeGridPoints( T*  x_inout,  T*  y_inout, T* z_inout )
+    {
+        long i = 0 ;
+        if (dimw_ == 3) {
+            for (const auto& vit :   vertices(gridView_, Dune::Partitions::all) )
+            {
+                // if (i < nvertices_) // As we are templated on the Dune::PartitionSet<partitions>, this cannot change
+                auto xyz_local = vit.geometry().corner(0);  // verticies only have one corner
+                x_inout[i] = static_cast<T>(xyz_local[0]) ;
+                y_inout[i] = static_cast<T>(xyz_local[1]) ;
+                z_inout[i] = static_cast<T>(xyz_local[2]) ; 
+                i++ ;
+            }
+        } else if (dimw_ == 2)  {
+            for (const auto& vit :   vertices(gridView_, Dune::Partitions::all) )
+            {      
+                // if (i < nvertices_) // As we are templated on the Dune::PartitionSet<partitions>, this cannot change
+                auto xyz_local = vit.geometry().corner(0);  // verticies only have one corner
+                x_inout[i] = static_cast<T>(xyz_local[0]) ;
+                y_inout[i] = static_cast<T>(xyz_local[1]) ;
+                z_inout[i] = static_cast<T>(0.0);
+                i++ ;
+            }
+        }
+        return i ;
+    }
+
+    /**
+     Write positions of vertices as array of structures : x,y,z,x,y,z,x,y,z,...
+
+     Returns the number of vertices written
+    */
+    template <typename T> 
+    long writeGridPoints_AOS( T*  xyz_inout )
+    {
+        long i = 0 ;
+        if (dimw_ == 3) {
+            for (const auto& vit :   vertices(gridView_, Dune::Partitions::all))
+            {
+                auto xyz_local = vit.geometry().corner(0);
+                xyz_inout[i++] = static_cast<T>(xyz_local[0]) ;
+                xyz_inout[i++] = static_cast<T>(xyz_local[1]) ;
+                xyz_inout[i++] = static_cast<T>(xyz_local[2]) ;
+                
+            }
+        } else if (dimw_ == 2)  {
+            for (const auto& vit :   vertices(gridView_, Dune::Partitions::all))
+            {
+                auto xyz_local = vit.geometry().corner(0);
+                xyz_inout[i++] = static_cast<T>(xyz_local[0]) ;
+                xyz_inout[i++] = static_cast<T>(xyz_local[1]) ;
+                xyz_inout[i++] = static_cast<T>(0.0) ;  
+            }
+        }
+        return ( (i) / 3 );
+    }
+
+    /**
+     Write positions of vertices as structure of arrays  : x,x,x,...,y,y,y,...,z,z,z,...
+
+     Returns the number of vertices written
+    */
+    template <typename T> 
+    long writeGridPoints_SOA( T*  xyz_inout )
+    {
+        long i = 0 ;
+        // Get offsets into structure
+        T * xyz_inout_y = xyz_inout + nvertices_ ;
+        T * xyz_inout_z = xyz_inout + (2*nvertices_) ;
+
+        if (dimw_ == 3) {
+            for (const auto& vit :   vertices(gridView_, Dune::Partitions::all))
+            {     
+                auto xyz_local = vit.geometry().corner(0);
+                xyz_inout[i] = static_cast<T>(xyz_local[0]) ;
+                xyz_inout_y[i]= static_cast<T>(xyz_local[1]) ;
+                xyz_inout_z[i] = static_cast<T>(xyz_local[2]) ;
+                i++ ;
+            }
+        } else if (dimw_ == 2)  {
+            for (const auto& vit :   vertices(gridView_, Dune::Partitions::all))
+            {     
+                auto xyz_local = vit.geometry().corner(0);
+                xyz_inout[i] = static_cast<T>(xyz_local[0]) ;
+                xyz_inout_y[i]= static_cast<T>(xyz_local[1]) ;
+                xyz_inout_z[i] = static_cast<T>(0.0);  
+                i++ ;
+            }
+        }
+        return (i) ;
+    }
+
+    /**
+    * Write the connectivity array - directly to the pointer given in paramater 1
+      Reorders the indecies as selected either in DUNE order or  VTK order.
+
+      Returns the number of corner indices written.
+    */
+    template <typename I>
+    long writeConnectivity(I * connectivity_inout, ConnectivityVertexOrder whichOrder)
+    {
+        long i = 0 ;
+        if ( whichOrder == DUNE )  {
+            // DUNE order
+            for (const auto& cit :  elements(gridView_, dunePartition_))
+            {  
+              auto cell_corners = cit.geometry().corners() ;
+              for( auto vx = 0; vx < cell_corners; ++ vx )  
+              {
+                  const int vxIdx = gridView_.indexSet().subIndex( cit, vx, 3 );
+                  connectivity_inout[i + vx] = vxIdx ;
+              }
+              i += cell_corners ; 
+            }
+        } else {
+            // VTK order
+            for (const auto& cit :  elements(gridView_, dunePartition_))
+            {
+              auto cell_corners = cit.geometry().corners() ;
+              for( auto vx = 0; vx < cell_corners; ++ vx )  
+              {
+                  const int vxIdx = gridView_.indexSet().subIndex( cit, vx, 3 );
+                  int vtkOrder ; 
+                  vtkOrder = Dune::VTK::renumber(cit.type(), vx) ;
+                  connectivity_inout[i + vtkOrder] = vxIdx ;
+              }
+              i += cell_corners ; 
+            }
+        }
+        return (i) ;
+    }
+
+    /**
+    * Write the offsets values  - directly to the pointer given in paramater 1
+      Returns the number of offset values written, which should be 1 greater than ncells_ 
+      or -1 if an error was detected
+    */
+    template <typename I>
+    long writeOffsetsCells( I* offsets_inout  )
+    {
+        long i = 1 ;
+        offsets_inout[0] = 0 ;
+        for (const auto& cit :  elements(gridView_, dunePartition_))
+        {  
+            auto cell_corners = cit.geometry().corners() ;
+            offsets_inout[i] = offsets_inout[i-1] +  cell_corners ;
+            i++ ;
+        }
+        return (i) ;  // This should be 1 greater than ncells_
+    }
+
+    /**
+    * Write the Cell types array - directly to the pointer given in paramater 1
+    */
+    template <typename I>
+    long writeCellTypes( I* types_inout)
+    {
+        int i = 0 ;
+        for (const auto& cit :  elements(gridView_, dunePartition_))
+        {
+              I vtktype = static_cast<I>(Dune::VTK::geometryType(cit.type()));
+              types_inout[i++] = vtktype ;
+        }
+        return (i) ;
+    }
+
+    std::string getPartitionTypeString (  )
+    {
+        if (this->dunePartition_ ==  Dune::Partitions::all)
+            return (std::string("Dune::Partitions::all")) ;
+        if (this->dunePartition_ ==  Dune::Partitions::interior)
+            return (std::string("Dune::Partitions::interior")) ;
+        if (this->dunePartition_ ==  Dune::Partitions::interiorBorder)
+            return (std::string("Dune::Partitions::interiorBorder")) ;
+        if (this->dunePartition_ ==  Dune::Partitions::interiorBorderOverlap)
+            return (std::string("Dune::Partitions::interiorBorderOverlap")) ;
+        if (this->dunePartition_ ==  Dune::Partitions::front)
+            return (std::string("Dune::Partitions::front")) ;
+        if (this->dunePartition_ ==  Dune::Partitions::interiorBorderOverlapFront)
+            return (std::string("Dune::Partitions::InteriorBorderOverlapFront")) ;
+        if (this->dunePartition_ ==  Dune::Partitions::border)
+            return (std::string("Dune::Partitions::border")) ;
+        if (this->dunePartition_ ==  Dune::Partitions::ghost)
+            return (std::string("Dune::Partitions::ghost")) ;
+        
+        return (std::string("Unknown Dune::PartitionSet<>")) ;
+    }
+
+    Dune::PartitionSet<partitions> getPartition ( void )
+    {
+        return ( this->dunePartition_ ) ;
+    }
+
+    void   printGridDetails()
+    {
+        std::cout << "Dune Partition = " << partition_value_ << ", " << getPartitionTypeString()  << std::endl ;
+        printNCells() ;
+        printNVertices() ;
+        printNCorners() ;
+    }
+
+    void printNCells()
+    {
+        std::cout << "ncells = " << ncells_ << std::endl ;
+    }
+
+    void printNVertices()
+    {
+        std::cout << "nvertices = " << nvertices_ << std::endl ;
+    }
+
+    void printNCorners()
+    {
+        std::cout << "ncorners = " << ncorners_ << std::endl ;
+    }
+    
+    int getNCells()
+    {
+        return(ncells_) ;
+    }
+
+    int getNVertices()
+    {
+        return(nvertices_) ;
+    }
+
+    int getNCorners()
+    {
+        return(ncorners_) ;
+    }
+
+    std::string getError()
+    {
+        return error_strm_.str() ;
+    }
+
+    void clearError()
+    {
+         error_strm_.str("") ;
+    }
+
+    bool hasError()
+    {
+        if ( error_strm_.str().length() > 0 ) 
+            return true ;
+        else 
+            return false ;
+    }
+
+  protected:
+
+    GridView gridView_;  // the grid
+    
+    Dune::PartitionSet<partitions>  dunePartition_ ;
+    unsigned int partition_value_ ;
+
+    /**
+    Current partition grid information
+    */
+    int ncells_;
+    /**
+    Current partition grid information
+    */
+    int nvertices_;
+    /**
+    Current partition grid information
+    */
+    int ncorners_; 
+    
+    int dimw_ ;  // dimensions of the input grid
+    
+  private:
+    std::stringstream error_strm_ ;
+
+  };
+
+}
+
+#endif 

--- a/opm/simulators/utils/UnsupportedFlowKeywords.cpp
+++ b/opm/simulators/utils/UnsupportedFlowKeywords.cpp
@@ -102,7 +102,6 @@ const KeywordValidation::UnsupportedKeywords& unsupportedKeywords()
         {"COMPVEL", {true, std::nullopt}},
         {"CPIFACT", {true, std::nullopt}},
         {"CPIFACTL", {true, std::nullopt}},
-        {"CSKIN", {true, std::nullopt}},
         {"CONNECTION", {true, std::nullopt}},
         {"CONNECTION_PROBE", {true, std::nullopt}},
         {"COORDSYS", {true, std::nullopt}},

--- a/opm/simulators/utils/initDamarisXmlFile.cpp
+++ b/opm/simulators/utils/initDamarisXmlFile.cpp
@@ -22,8 +22,6 @@
 
 namespace Opm::DamarisOutput
 {
-
-
 /*
     Below is the XML file for Damaris that is supported by Damaris.
 
@@ -37,7 +35,7 @@ namespace Opm::DamarisOutput
 std::string initDamarisXmlFile()
 {
     std::string init_damaris = R"V0G0N(<?xml version="1.0"?>
-<simulation name="opm-flow" language="c" xmlns="http://damaris.gforge.inria.fr/damaris/model">
+<simulation name="_SIM_NAME_" language="c" xmlns="http://damaris.gforge.inria.fr/damaris/model">
 <architecture>
     <domains count="1"/>
     <dedicated cores="_DC_REGEX_" nodes="_DN_REGEX_"/>
@@ -46,28 +44,27 @@ std::string initDamarisXmlFile()
     <queue  name="queue" size="300" />
 </architecture>
 
-<data>
+  <data>
     <parameter name="n_elements_total"     type="int" value="1" />
     <parameter name="n_elements_local"     type="int" value="1" />
     <parameter name="n"     type="int" value="1" />
 
-    <layout   name="zonal_layout_usmesh_integer"  type="int"   dimensions="n_elements_local"   global="n_elements_total"   comment="For the field data e.g. Pressure"  />
-    <variable name="GLOBAL_CELL_INDEX"            layout="zonal_layout_usmesh_integer"     type="scalar"  visualizable="false"  time-varying="false" store="_MYSTORE_OR_EMPTY_REGEX_" centering="zonal" />
-    <layout   name="zonal_layout_usmesh"          type="double" dimensions="n_elements_local"   global="n_elements_total"   comment="For the field data e.g. Pressure"  />
-    <variable name="PRESSURE"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="unstructured_mesh"  unit="Bar"  centering="zonal"  time-varying="true"  
-                                                                        select-file="GLOBAL_CELL_INDEX" store="_MYSTORE_OR_EMPTY_REGEX_"   script="_PYTHON_XML_NAME_" />
+    <layout   name="zonal_layout_usmesh_integer"             type="int" dimensions="n_elements_local"   global="n_elements_total"   comment="For the field data e.g. Pressure"  />
+    <variable name="GLOBAL_CELL_INDEX"    layout="zonal_layout_usmesh_integer"     type="scalar"  visualizable="false"  time-varying="false"  centering="zonal" />
+    <layout   name="zonal_layout_usmesh"             type="double" dimensions="n_elements_local"   global="n_elements_total"   comment="For the field data e.g. Pressure"  />
+    <variable name="PRESSURE"    layout="zonal_layout_usmesh"     type="scalar"  visualizable="true"  mesh="us_mesh"   unit="_PRESSURE_UNIT_"   centering="zonal" select-file="GLOBAL_CELL_INDEX" store="_MYSTORE_OR_EMPTY_REGEX_"  script="PythonScript" />
+
     _MORE_VARIABLES_REGEX_
+    <variable name="MPI_RANK"  layout="zonal_layout_usmesh_integer"   type="scalar"  visualizable="true" mesh="us_mesh" unit="rank"  centering="zonal"  store="_MYSTORE_OR_EMPTY_REGEX_" time-varying="false"  select-file="GLOBAL_CELL_INDEX"  script="PythonScript" comment="The MPI rank of each cell"/>
     
-    <variable name="MPI_RANK"  layout="zonal_layout_usmesh_integer"   type="scalar"  visualizable="true" mesh="unstructured_mesh" unit="rank"  centering="zonal"  select-file="GLOBAL_CELL_INDEX"  store="#" time-varying="false"  script="#" comment="The cells MPI rank"/>
-    
-    <variable name="KRNSW_GO"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="unstructured_mesh"  unit=""  centering="zonal"     time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"   script="_PYTHON_XML_NAME_" />
-    <variable name="KRNSW_OW"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="_MESHNAME_OR_HASH_"  unit=""  centering="zonal"     time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"   script="_PYTHON_XML_NAME_" />
-    <variable name="PCSWM_GO"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="_MESHNAME_OR_HASH_"  unit=""  centering="zonal"     time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"   script="_PYTHON_XML_NAME_" />
-    <variable name="PCSWM_OW"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="_MESHNAME_OR_HASH_"  unit=""  centering="zonal"     time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"   script="_PYTHON_XML_NAME_" />
-    <variable name="PPCW"      layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="_MESHNAME_OR_HASH_"  unit="Bar"  centering="zonal"  time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"   script="_PYTHON_XML_NAME_" />    
-    <variable name="RS"        layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="_MESHNAME_OR_HASH_"  unit="Bar"  centering="zonal"  time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"   script="_PYTHON_XML_NAME_" comment="Dissolved Gas units Gas Oil Ratio" />
-    <variable name="RV"        layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="_MESHNAME_OR_HASH_"  unit="Bar"  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX" store="#"  script="_PYTHON_XML_NAME_" />
-    <variable name="SOMAX"     layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="_MESHNAME_OR_HASH_"  unit=""     centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX" store="#"  script="#" />
+    <variable name="KRNSW_GO"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"     time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"   script="#" />
+    <variable name="KRNSW_OW"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"     time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"   script="#" />
+    <variable name="PCSWM_GO"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"     time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"   script="#" />
+    <variable name="PCSWM_OW"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"     time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"   script="#" />
+    <variable name="PPCW"      layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit="Bar"  centering="zonal"  time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"   script="#" />    
+    <variable name="RS"        layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit="Bar"  centering="zonal"  time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"   script="#" comment="Dissolved Gas units Gas Oil Ratio" />
+    <variable name="RV"        layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit="Bar"  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX" store="#"  script="#" />
+    <variable name="SOMAX"     layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""     centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX" store="#"  script="#" />
     <variable name="1OVERBG"   layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />
     <variable name="1OVERBO"   layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />
     <variable name="1OVERBW"   layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />
@@ -81,8 +78,6 @@ std::string initDamarisXmlFile()
     <variable name="WAT_DEN"   layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />
     <variable name="WAT_VISC"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />
 
-    
-    
     <variable name="2FBF"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"   time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
     <variable name="4FBF"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
     <variable name="DFBF"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
@@ -109,30 +104,27 @@ std::string initDamarisXmlFile()
     <variable name="WIPG"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
     <variable name="WIPL"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
     <variable name="WIPR"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"  time-varying="true"  select-file="GLOBAL_CELL_INDEX"  store="#"  script="#" />     
-    
-    
+
     <parameter name="n_coords_local"     type="int" value="1" />
     <layout    name="n_coords_layout"    type="double" dimensions="n_coords_local"   comment="For the individual x, y and z coordinates of the mesh vertices, these values are referenced in the topologies/topo/subelements/connectivity_pg data"  />
     <group name="coordset/coords/values"> 
-        <variable name="x"    layout="n_coords_layout"  type="scalar"  visualizable="false"  unit="m"   script="_PYTHON_XML_NAME_" time-varying="false" />
-        <variable name="y"    layout="n_coords_layout"  type="scalar"  visualizable="false"  unit="m"   script="_PYTHON_XML_NAME_" time-varying="false" />
-        <variable name="z"    layout="n_coords_layout"  type="scalar"  visualizable="false"  unit="m"   script="_PYTHON_XML_NAME_" time-varying="false" />
+        <variable name="x"    layout="n_coords_layout"  type="scalar"  visualizable="false"  unit="m"   script="_MAKE_AVAILABLE_IN_PYTHON_" time-varying="false" />
+        <variable name="y"    layout="n_coords_layout"  type="scalar"  visualizable="false"  unit="m"   script="_MAKE_AVAILABLE_IN_PYTHON_" time-varying="false" />
+        <variable name="z"    layout="n_coords_layout"  type="scalar"  visualizable="false"  unit="m"   script="_MAKE_AVAILABLE_IN_PYTHON_" time-varying="false" />
     </group>
-    
-    
+
     <parameter name="n_connectivity_ph"        type="int"  value="1" />
     <layout    name="n_connections_layout_ph"  type="int"  dimensions="n_connectivity_ph"   comment="Layout for connectivities "  />
     <parameter name="n_offsets_types_ph"       type="int"  value="1" />
-    <layout    name="n_offsets_layout_ph"      type="int"  dimensions="n_offsets_types_ph+1"  comment="Layout for the offsets_ph"  />
+    <layout    name="n_offsets_layout_ph"      type="int"  dimensions="n_offsets_types_ph + 1"  comment="Layout for the offsets_ph"  />
     <layout    name="n_types_layout_ph"        type="char" dimensions="n_offsets_types_ph"  comment="Layout for the types_ph "  />
     <group name="topologies/topo/elements">
-        <variable name="connectivity"  layout="n_connections_layout_ph"  type="scalar"  visualizable="false"  script="_PYTHON_XML_NAME_" time-varying="false" />
-        <variable name="offsets"       layout="n_offsets_layout_ph"      type="scalar"  visualizable="false"  script="_PYTHON_XML_NAME_" time-varying="false" />
-        <variable name="types"         layout="n_types_layout_ph"        type="scalar"  visualizable="false"  script="_PYTHON_XML_NAME_" time-varying="false" />
+        <variable name="connectivity" layout="n_connections_layout_ph"  type="scalar"  visualizable="false"    script="_MAKE_AVAILABLE_IN_PYTHON_" time-varying="false" />
+        <variable name="offsets"      layout="n_offsets_layout_ph"    type="scalar"  visualizable="false"     script="_MAKE_AVAILABLE_IN_PYTHON_" time-varying="false" />
+        <variable name="types"        layout="n_types_layout_ph"    type="scalar"  visualizable="false"    script="_MAKE_AVAILABLE_IN_PYTHON_" time-varying="false" />
     </group>
-    
-    
-    <mesh name="unstructured_mesh" type="unstructured" topology="3" time-varying="false" 
+
+    <mesh name="us_mesh" type="unstructured" topology="3" time-varying="false" 
              comment="This Mesh definition is for connection with Paraview.
                       This definition references the variables that define an unstructured mesh specified above." >
         <coord                name="coordset/coords/values/x"  unit="m"    />
@@ -147,7 +139,7 @@ std::string initDamarisXmlFile()
         <polyhedral_cell_faces_offsets       name="#"                      />
         <polyhedral_n_faces_per_cell         name="#"                      />
     </mesh>
-    
+
 </data>
 
 <storage>
@@ -159,17 +151,17 @@ std::string initDamarisXmlFile()
 </storage>
 
 <scripts>
-    <pyscript name="PythonScript" file="_PYTHON_OR_EMPTY_REGEX_" language="python" frequency="1" scheduler-file="" nthreads="0" keep-workers="no" />
+    <pyscript name="PythonScript" file="_PYTHON_SCRIPT_" language="python" frequency="1" scheduler-file="" nthreads="0" keep-workers="no" />
 </scripts>
 
-<!-- paraview update-frequency="1" write-vtk="0" write-vtk-binary="false">
-        <script>_PARAVIEWPY_OR_EMPTY_REGEX_</script>
-</paraview -->
+<paraview update-frequency="1" write-vtk="0" write-vtk-binary="false" >
+        <script>_PARAVIEW_PYTHON_SCRIPT_</script>
+</paraview>
 
 <actions>
 </actions>
 
-<log FileName="_PATH_REGEX_/damaris_log/opm-flow" RotationSize="5" LogFormat="[%TimeStamp%]: %Message%"  Flush="true"  LogLevel="info" />
+<log FileName="_PATH_REGEX_/damaris_log/_SIM_NAME_" RotationSize="5" LogFormat="[%TimeStamp%]: %Message%"  Flush="True"  LogLevel="_LOG_LEVEL_" />
 
 </simulation>)V0G0N";
 

--- a/opm/simulators/utils/initDamarisXmlFile.cpp
+++ b/opm/simulators/utils/initDamarisXmlFile.cpp
@@ -52,10 +52,10 @@ std::string initDamarisXmlFile()
     <layout   name="zonal_layout_usmesh_integer"             type="int" dimensions="n_elements_local"   global="n_elements_total"   comment="For the field data e.g. Pressure"  />
     <variable name="GLOBAL_CELL_INDEX"    layout="zonal_layout_usmesh_integer"     type="scalar"  visualizable="false"  time-varying="false"  centering="zonal" />
     <layout   name="zonal_layout_usmesh"             type="double" dimensions="n_elements_local"   global="n_elements_total"   comment="For the field data e.g. Pressure"  />
-    <variable name="PRESSURE"    layout="zonal_layout_usmesh"     type="scalar"  visualizable="true"  mesh="us_mesh"   unit="_PRESSURE_UNIT_"   centering="zonal" select-file="GLOBAL_CELL_INDEX" store="_MYSTORE_OR_EMPTY_REGEX_"  script="PythonScript" />
+    <variable name="PRESSURE"    layout="zonal_layout_usmesh"     type="scalar"  visualizable="true"  mesh="us_mesh"   unit="_PRESSURE_UNIT_"   centering="zonal" select-file="GLOBAL_CELL_INDEX" store="_MYSTORE_OR_EMPTY_REGEX_"  script="_MAKE_AVAILABLE_IN_PYTHON_" />
 
     _MORE_VARIABLES_REGEX_
-    <variable name="MPI_RANK"  layout="zonal_layout_usmesh_integer"   type="scalar"  visualizable="true" mesh="us_mesh" unit="rank"  centering="zonal"  store="_MYSTORE_OR_EMPTY_REGEX_" time-varying="false"  select-file="GLOBAL_CELL_INDEX"  script="PythonScript" comment="The MPI rank of each cell"/>
+    <variable name="MPI_RANK"  layout="zonal_layout_usmesh_integer"   type="scalar"  visualizable="true" mesh="us_mesh" unit="rank"  centering="zonal"  store="_MYSTORE_OR_EMPTY_REGEX_" time-varying="false"  select-file="GLOBAL_CELL_INDEX"  script="_MAKE_AVAILABLE_IN_PYTHON_" comment="The MPI rank of each cell"/>
     
     <variable name="KRNSW_GO"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"     time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"   script="#" />
     <variable name="KRNSW_OW"  layout="zonal_layout_usmesh"  type="scalar"  visualizable="true" mesh="#"  unit=""  centering="zonal"     time-varying="true" select-file="GLOBAL_CELL_INDEX"  store="#"   script="#" />
@@ -161,7 +161,7 @@ std::string initDamarisXmlFile()
 <actions>
 </actions>
 
-<log FileName="_PATH_REGEX_/damaris_log/_SIM_NAME_" RotationSize="5" LogFormat="[%TimeStamp%]: %Message%"  Flush="false"  LogLevel="_LOG_LEVEL_" />
+<log FileName="_PATH_REGEX_/damaris_log/_SIM_NAME_" RotationSize="5" LogFormat="[%TimeStamp%]: %Message%"  Flush="_LOG_FLUSH_"  LogLevel="_LOG_LEVEL_" />
 
 </simulation>)V0G0N";
 

--- a/opm/simulators/utils/initDamarisXmlFile.cpp
+++ b/opm/simulators/utils/initDamarisXmlFile.cpp
@@ -151,17 +151,17 @@ std::string initDamarisXmlFile()
 </storage>
 
 <scripts>
-    <pyscript name="PythonScript" file="_PYTHON_SCRIPT_" language="python" frequency="1" scheduler-file="" nthreads="0" keep-workers="no" />
+    <_DISABLEPYTHONSTART_pyscript name="PythonScript" file="_PYTHON_SCRIPT_" language="python" frequency="1" scheduler-file="" nthreads="0" keep-workers="no" /_DISABLEPYTHONFIN_>
 </scripts>
 
-<paraview update-frequency="1" write-vtk="0" write-vtk-binary="false" >
+<_DISABLEPARAVIEWSTART_paraview update-frequency="1" write-vtk="0" write-vtk-binary="false" >
         <script>_PARAVIEW_PYTHON_SCRIPT_</script>
-</paraview>
+</paraview _DISABLEPARAVIEWFIN_>
 
 <actions>
 </actions>
 
-<log FileName="_PATH_REGEX_/damaris_log/_SIM_NAME_" RotationSize="5" LogFormat="[%TimeStamp%]: %Message%"  Flush="True"  LogLevel="_LOG_LEVEL_" />
+<log FileName="_PATH_REGEX_/damaris_log/_SIM_NAME_" RotationSize="5" LogFormat="[%TimeStamp%]: %Message%"  Flush="false"  LogLevel="_LOG_LEVEL_" />
 
 </simulation>)V0G0N";
 

--- a/regressionTests.cmake
+++ b/regressionTests.cmake
@@ -519,6 +519,41 @@ add_test_compareECLFiles(CASENAME udq_in_actionx
                          REL_TOL ${rel_tol}
                          DIR udq_actionx)
 
+add_test_compareECLFiles(CASENAME cskin-01
+                         FILENAME CSKIN-01
+                         SIMULATOR flow
+                         ABS_TOL ${abs_tol}
+                         REL_TOL ${rel_tol}
+                         DIR cskin)
+
+add_test_compareECLFiles(CASENAME cskin-02
+                         FILENAME CSKIN-02
+                         SIMULATOR flow
+                         ABS_TOL ${abs_tol}
+                         REL_TOL ${rel_tol}
+                         DIR cskin)
+
+add_test_compareECLFiles(CASENAME cskin-03
+                         FILENAME CSKIN-03
+                         SIMULATOR flow
+                         ABS_TOL ${abs_tol}
+                         REL_TOL ${rel_tol}
+                         DIR cskin)
+
+add_test_compareECLFiles(CASENAME cskin-04
+                         FILENAME CSKIN-04
+                         SIMULATOR flow
+                         ABS_TOL ${abs_tol}
+                         REL_TOL ${rel_tol}
+                         DIR cskin)
+
+add_test_compareECLFiles(CASENAME cskin-05
+                         FILENAME CSKIN-05
+                         SIMULATOR flow
+                         ABS_TOL ${abs_tol}
+                         REL_TOL ${rel_tol}
+                         DIR cskin)
+
 add_test_compareECLFiles(CASENAME co2store
                          FILENAME CO2STORE
                          SIMULATOR flow

--- a/tests/test_RestartSerialization.cpp
+++ b/tests/test_RestartSerialization.cpp
@@ -63,6 +63,11 @@ namespace Opm::Properties {
             using InheritsFrom = std::tuple<EbosTypeTag, FlowTimeSteppingParameters>;
         };
     }
+
+    template<>
+    struct LinearSolverBackend<TTag::TestRestartTypeTag, TTag::FlowIstlSolverParams> {
+        using type = ISTLSolverEbos<TTag::TestRestartTypeTag>;
+    };
 }
 
 template<class T>


### PR DESCRIPTION
Top commit here fixes the build. I rebased on master so you can't merge but you can just cherry-pick or adopt the commit as you see fit.

Fundamentally, the settings are registered in a TypeTag through the static member function registerParams in the DamarisWriter class. They are not registered in the PreTypeTag you tried to use and you also need to include the header with the settings definition to have them in scope. We do not want to register them in the PreTypeTag because that would mean we have to instance a whole EclProblem (which again means the whole simulator stack). We only want to register them in the actual TypeTag used by the simulator.

For that reason I have changed it here so there is a frontend template that grabs the settings then calls on to the rest of the code. You then call this on the TypeTag used by the EclProblem / DamarisWriter / etc in the appropriate spot.

I also changed it to use the Parallel::Communication wrapper for mpi communicators. No raw MPI_Comm's should be passed around. It is castable to MPI_Comm but you should prefer to use the .rank(), .size() methods and only use raw mpi calls when absolutely necessary. Finally I removed usage of INT_MAX et al and used the proper c++ std::numeric_limits&lt;int&gt;::max()